### PR TITLE
Map coordinates and LinearInit func

### DIFF
--- a/pkg/matrix/matrix.go
+++ b/pkg/matrix/matrix.go
@@ -12,47 +12,47 @@ import (
 // It returns error if passed in matrix is nil, has zero size or requested number
 // of columns exceeds the number of columns in the matrix passed in as parameter.
 func ColsMax(cols int, m *mat64.Dense) ([]float64, error) {
-	return withValidCols(cols, m, mat64.Max)
+	return withValidDim("cols", cols, m, mat64.Max)
 }
 
 // ColsMin returns a slice of min values of first cols number of matrix columns
 // It returns error if passed in matrix is nil, has zero size or requested number
 // of columns exceeds the number of columns in the matrix passed in as parameter.
 func ColsMin(cols int, m *mat64.Dense) ([]float64, error) {
-	return withValidCols(cols, m, mat64.Min)
+	return withValidDim("cols", cols, m, mat64.Min)
 }
 
-// ColsMean returns a slice of mean values of first cols number of matrix columns
-// It returns error if passed in matrix is nil, has zero size or requested number
-// of columns exceeds the number of columns in the matrix passed in as parameter.
+// ColsMean returns a slice of mean values of first cols matrix columns
+// It returns error if passed in matrix is nil or has zero size or requested number
+// of columns exceeds the number of columns in matrix m.
 func ColsMean(cols int, m *mat64.Dense) ([]float64, error) {
-	return withValidCols(cols, m, mean)
+	return withValidDim("cols", cols, m, mean)
 }
 
-// ColsStdev returns a slice of standard deviatioasn of first cols number of matrix columns
-// It returns error if passed in matrix is nil, has zero size or requested number
-// of columns exceeds the number of columns in the matrix passed in as parameter.
+// ColsStdev returns a slice of standard deviations of first cols matrix columns
+// It returns error if passed in matrix is nil or has zero size or requested number
+// of columns exceeds the number of columns in matrix m.
 func ColsStdev(cols int, m *mat64.Dense) ([]float64, error) {
-	return withValidCols(cols, m, stdev)
+	return withValidDim("cols", cols, m, stdev)
 }
 
-// RowsMax returns a slice of max values of first rows number of matrix rows.
-// It returns error if passed in matrix is nil, has zero size or requested number
-// of rows exceeds the number of rows in the matrix passed in as parameter.
+// RowsMax returns a slice of max values of first rows matrix rows.
+// It returns error if passed in matrix is nil or has zero size or requested number
+// of rows exceeds the number of rows in matrix m.
 func RowsMax(rows int, m *mat64.Dense) ([]float64, error) {
-	return withValidRows(rows, m, mat64.Max)
+	return withValidDim("rows", rows, m, mat64.Max)
 }
 
-// RowsMin returns a slice of min values of first rows number of matrix rows.
-// It returns error if passed in matrix is nil, has zero size or requested number
-// of rows exceeds the number of rows in the matrix passed in as parameter.
+// RowsMin returns a slice of min values of first rows matrix rows.
+// It returns error if passed in matrix is nil or has zero size or requested number
+// of rows exceeds the number of rows in matrix m.
 func RowsMin(rows int, m *mat64.Dense) ([]float64, error) {
-	return withValidRows(rows, m, mat64.Min)
+	return withValidDim("rows", rows, m, mat64.Min)
 }
 
-// MakeRandom creates a new matrix rows x cols matrix which is initialized
-// to random numbers uniformly distributed in interval [min, max].
-// MakeRandom fails if invalid matrix dimensions are requested.
+// MakeRandom creates a new matrix with provided number of rows and columns
+// which is initialized to random numbers uniformly distributed in interval [min, max].
+// MakeRandom fails if non-positive matrix dimensions are requested.
 func MakeRandom(rows, cols int, min, max float64) (*mat64.Dense, error) {
 	return withValidDims(rows, cols, func() (*mat64.Dense, error) {
 		// set random seed
@@ -83,7 +83,7 @@ func MakeConstant(rows, cols int, val float64) (*mat64.Dense, error) {
 }
 
 // AddConst adds a constant value to every element of matrix
-// It modifies the matrix passed in.
+// It modifies the matrix m passed in as a paramter.
 // AddConstant fails with error if empty matrix is supplied
 func AddConst(val float64, m *mat64.Dense) (*mat64.Dense, error) {
 	if m == nil {
@@ -101,6 +101,70 @@ func AddConst(val float64, m *mat64.Dense) (*mat64.Dense, error) {
 	})
 }
 
+// viewFunc defines matrix dimension view function
+type viewFunc func(int) *mat64.Vector
+
+// dimFn applies function fn to first count matrix rows or columns.
+// dim can be either set to rows or cols.
+// dimFn collects the results into a slice and returns it
+func dimFn(dim string, count int, m *mat64.Dense, fn func(mat64.Matrix) float64) []float64 {
+	res := make([]float64, count)
+	var viewFn viewFunc
+	switch dim {
+	case "rows":
+		viewFn = m.RowView
+	case "cols":
+		viewFn = m.ColView
+	}
+	for i := 0; i < count; i++ {
+		res[i] = fn(viewFn(i))
+	}
+	return res
+}
+
+// withValidDim executes function fn on first count of matrix columns or rows.
+// It collects the results of each calculation and returns it in a slice.
+// It returns error if either matrix m is nil, has zero size or requested number of
+// particular dimension is larger than the matrix m dimensions.
+func withValidDim(dim string, count int, m *mat64.Dense,
+	fn func(mat64.Matrix) float64) ([]float64, error) {
+	// matrix can't be nil
+	if m == nil {
+		return nil, fmt.Errorf("Invalid matrix supplied: %v\n", m)
+	}
+	rows, cols := m.Dims()
+	switch dim {
+	case "rows":
+		if rows == 0 {
+			return nil, fmt.Errorf("Invalid number of rows supplied: %v\n", m)
+		}
+		if count > rows {
+			return nil, fmt.Errorf("Row count exceeds matrix rows: %d\n", count)
+		}
+	case "cols":
+		if cols == 0 {
+			return nil, fmt.Errorf("Invalid number of columns supplied: %v\n", m)
+		}
+		if count > cols {
+			return nil, fmt.Errorf("Column count exceeds matrix columns: %d\n", count)
+		}
+	}
+	return dimFn(dim, count, m, fn), nil
+}
+
+// withValidDims validates if the rows and cols are valid matrix dimensions
+// It returns error if either rows or cols are invalid i.e. non-positive integers
+func withValidDims(rows, cols int, fn func() (*mat64.Dense, error)) (*mat64.Dense, error) {
+	// can not create matrix with negative dimensions
+	if rows <= 0 {
+		return nil, fmt.Errorf("Invalid number of rows: %d\n", rows)
+	}
+	if cols <= 0 {
+		return nil, fmt.Errorf("Invalid number of columns: %d\n", cols)
+	}
+	return fn()
+}
+
 // returns a mean valur for a given matrix
 func mean(m mat64.Matrix) float64 {
 	r, c := m.Dims()
@@ -113,73 +177,4 @@ func stdev(m mat64.Matrix) float64 {
 	col := make([]float64, r)
 	mat64.Col(col, 0, m)
 	return stat.StdDev(col, nil)
-}
-
-// colsFn applies function fn on each column, collects the results into slice and returns it
-func colsFn(cols int, m *mat64.Dense, fn func(mat64.Matrix) float64) []float64 {
-	res := make([]float64, cols)
-	for i := 0; i < cols; i++ {
-		res[i] = fn(m.ColView(i))
-	}
-	return res
-}
-
-// rowsFn applies function fn on each row, collects the results into slice and returns it
-func rowsFn(rows int, m *mat64.Dense, fn func(mat64.Matrix) float64) []float64 {
-	res := make([]float64, rows)
-	for i := 0; i < rows; i++ {
-		res[i] = fn(m.RowView(i))
-	}
-	return res
-}
-
-// withValidCols validates that the passed in matrix is non-nil, has non-zero number of columns
-// and executes the fn function on count number of matrix columns. It collects the results of
-// each calculation and returns it in a slice.
-// It returns error if either the passed in matrix is nil, has zero size or requested number of
-// columns is larger than the number of matrix columns.
-func withValidCols(count int, m *mat64.Dense, fn func(mat64.Matrix) float64) ([]float64, error) {
-	if m == nil {
-		return nil, fmt.Errorf("Invalid matrix supplied: %v\n", m)
-	}
-	_, cols := m.Dims()
-	if cols == 0 {
-		return nil, fmt.Errorf("Invalid number of columns supplied: %v\n", m)
-	}
-	if count > cols {
-		return nil, fmt.Errorf("Column count exceeds matrix dimensions: %d\n", count)
-	}
-	return colsFn(count, m, fn), nil
-}
-
-// withValidRows validates that the passed in matrix is non-nil, has non-zero number of rows
-// and executes the fn function on count number of matrix rows. It collects the results of
-// each calculation and returns it in a slice.
-// It returns error if either the passed in matrix is nil, has zero size or requested number of
-// rows is larger than the number of matrix rows.
-func withValidRows(count int, m *mat64.Dense, fn func(mat64.Matrix) float64) ([]float64, error) {
-	if m == nil {
-		return nil, fmt.Errorf("Invalid matrix supplied: %v\n", m)
-	}
-	rows, _ := m.Dims()
-	if rows == 0 {
-		return nil, fmt.Errorf("Invalid number of rows supplied: %v\n", m)
-	}
-	if count > rows {
-		return nil, fmt.Errorf("Row count exceeds matrix dimensions: %d\n", count)
-	}
-	return rowsFn(count, m, fn), nil
-}
-
-// withValidDims validates the requested rows and cols matrix dimensions
-// It treturns error if either rows or cols are non-positive integers
-func withValidDims(rows, cols int, fn func() (*mat64.Dense, error)) (*mat64.Dense, error) {
-	// can not create matrix with negative dimensions
-	if rows <= 0 {
-		return nil, fmt.Errorf("Invalid number of rows: %d\n", rows)
-	}
-	if cols <= 0 {
-		return nil, fmt.Errorf("Invalid number of columns: %d\n", cols)
-	}
-	return fn()
 }

--- a/pkg/matrix/matrix_test.go
+++ b/pkg/matrix/matrix_test.go
@@ -13,8 +13,8 @@ var (
 	errInvMx     = "Invalid matrix supplied: %v\n"
 	errInvColsMx = "Invalid number of columns supplied: %v\n"
 	errInvRowsMx = "Invalid number of rows supplied: %v\n"
-	errExcCols   = "Column count exceeds matrix dimensions: %d\n"
-	errExcRows   = "Row count exceeds matrix dimensions: %d\n"
+	errExcCols   = "Column count exceeds matrix columns: %d\n"
+	errExcRows   = "Row count exceeds matrix rows: %d\n"
 )
 
 func TestRowsColsMax(t *testing.T) {

--- a/pkg/matrix/matrix_test.go
+++ b/pkg/matrix/matrix_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gonum/floats"
 	"github.com/gonum/matrix/mat64"
 	"github.com/stretchr/testify/assert"
 )
@@ -112,6 +113,38 @@ func TestColsMin(t *testing.T) {
 	assert.EqualError(err, fmt.Sprintf(errInvRowsMx, mx))
 }
 
+func TestColsMean(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.2, 3.4, 4.5, 6.7, 8.9, 10.0}
+	mx := mat64.NewDense(3, 2, data)
+	assert.NotNil(mx)
+	colsMean := []float64{4.8667, 6.7000}
+
+	_, cols := mx.Dims()
+	// check cols
+	me, err := ColsMean(cols, mx)
+	assert.NotNil(me)
+	assert.NoError(err)
+	assert.True(floats.EqualApprox(colsMean, me, 0.01))
+}
+
+func TestColsStdev(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []float64{1.2, 3.4, 4.5, 6.7, 8.9, 10.0}
+	mx := mat64.NewDense(3, 2, data)
+	assert.NotNil(mx)
+	colsStdev := []float64{3.8631, 3.3000}
+
+	_, cols := mx.Dims()
+	// check cols
+	sd, err := ColsStdev(cols, mx)
+	assert.NotNil(sd)
+	assert.NoError(err)
+	assert.True(floats.EqualApprox(colsStdev, sd, 0.01))
+}
+
 func TestMakeRandom(t *testing.T) {
 	assert := assert.New(t)
 
@@ -139,7 +172,7 @@ func TestMakeRandom(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestConstant(t *testing.T) {
+func TestMakeConstant(t *testing.T) {
 	assert := assert.New(t)
 
 	// all elements must be equal to 1.0
@@ -155,5 +188,23 @@ func TestConstant(t *testing.T) {
 	// Can't create new matrix
 	constMx, err = MakeConstant(-3, 10, 1.0)
 	assert.Nil(constMx)
+	assert.Error(err)
+}
+
+func TestAddConstant(t *testing.T) {
+	assert := assert.New(t)
+
+	// all elements must be equal to 1.0
+	val := 0.5
+	mx := mat64.NewDense(2, 2, []float64{1.0, 2.0, 2.5, 2.5})
+	mc := mat64.NewDense(2, 2, []float64{1.5, 2.5, 3.0, 3.0})
+
+	mx, err := AddConst(val, mx)
+	assert.NotNil(mx)
+	assert.NoError(err)
+	assert.True(mat64.EqualApprox(mx, mc, 0.01))
+	// incorrect matrix passed in
+	mx, err = AddConst(val, nil)
+	assert.Nil(mx)
 	assert.Error(err)
 }

--- a/som/config.go
+++ b/som/config.go
@@ -16,7 +16,7 @@ var UShape = map[string]bool{
 
 // CoordsInit maps supported grid coordinates function types to their implementations
 var CoordsInit = map[string]CoordsInitFunc{
-	"planar": PlaneGridCoords,
+	"planar": GridCoords,
 }
 
 // Neighb maps supported neighbourhood functions to their implementations

--- a/som/grid.go
+++ b/som/grid.go
@@ -2,17 +2,67 @@ package som
 
 import (
 	"fmt"
+	"math"
+	"strings"
 
+	"github.com/gonum/floats"
 	"github.com/gonum/matrix/mat64"
+	"github.com/gonum/stat"
 	"github.com/milosgajdos83/gosom/pkg/matrix"
+	"github.com/milosgajdos83/gosom/pkg/utils"
 )
+
+// GridDims tries to estimate the best dimensions of map from data matrix and given unit shape.
+// It determines the grid size from eigenvectors of input data: the grid dimensions are
+// calculated from the ratio of two highest input eigenvalues.
+// It returns error if the map dimensions could not be calculated.
+func GridDims(data *mat64.Dense, uShape string) ([]int, error) {
+	dataLen, dataDim := data.Dims()
+	// this is a simple heuristic - you can pick the scale > 5
+	mUnits := math.Ceil(5 * math.Sqrt(float64(dataLen)))
+	// if the data is 1D - we return [1 x mUnits] map dimensions
+	if dataDim == 1 && dataLen > 1 {
+		return []int{1, int(mUnits)}, nil
+	}
+	// Not enough data to calculate eigenvectors
+	// We will use heuristic: number of mUnits = square area of SOM
+	if dataLen < 2 {
+		gDim := math.Sqrt(mUnits)
+		return []int{int(gDim), int(gDim)}, nil
+	}
+	// We have more than 2 samples and more than 1D data
+	// Calculate eigenvalue ie. SVD singular values
+	_, eigVals, ok := stat.PrincipalComponents(data, nil)
+	if !ok {
+		return nil, fmt.Errorf("Could not determine Principal Components")
+	}
+	// by default we use 1:1 ratio of the map
+	ratio := 1.0
+	// pick first two components: we only support 2D data maps
+	// length check here is redundant, but let's make sure just in case
+	if len(eigVals) >= 2 {
+		if eigVals[0] != 0 && eigVals[1]*mUnits >= eigVals[0] {
+			ratio = math.Sqrt(eigVals[0] / eigVals[1])
+		}
+	}
+	// If the unit shape is hexagon, the ratio is modified a bit to take it into account
+	// Remember when using hexagon we don't get rectangle so the area != dimA * dimB
+	tmpDim := math.Sqrt(mUnits / ratio)
+	if strings.EqualFold(uShape, "hexagon") {
+		tmpDim = math.Sqrt(mUnits / ratio * math.Sqrt(0.75))
+	}
+	yDim := int(floats.Min([]float64{mUnits, tmpDim}))
+	xDim := int(mUnits / float64(yDim))
+	// Return map dimensions
+	return []int{xDim, yDim}, nil
+}
 
 // RandInit returns a matrix initialized to uniformly distributed random values
 // in each column in range between [max, min] where max and min are maximum and minmum values
-// in particular matrix column. The returned matrix has r number of rows and
+// in particular matrix column. The returned matrix has mUnits number of rows and
 // as many columns as the matrix passed in as a parameter.
 // It fails with error if the new matrix could not be initialized or if inMx is nil.
-func RandInit(inMx *mat64.Dense, rows int) (*mat64.Dense, error) {
+func RandInit(inMx *mat64.Dense, mUnits int, gridDims []int) (*mat64.Dense, error) {
 	// if nil matrix is passed in, return error
 	if inMx == nil {
 		return nil, fmt.Errorf("Invalid input matrix: %v\n", inMx)
@@ -30,13 +80,13 @@ func RandInit(inMx *mat64.Dense, rows int) (*mat64.Dense, error) {
 		return nil, err
 	}
 	// initialize matrix to rand values between 0.0 and 1.0
-	outMx, err := matrix.MakeRandom(rows, cols, 0.0, 1.0)
+	outMx, err := matrix.MakeRandom(mUnits, cols, 0.0, 1.0)
 	if err != nil {
 		return nil, err
 	}
 	for i := 0; i < cols; i++ {
 		col := outMx.ColView(i)
-		for j := 0; j < rows; j++ {
+		for j := 0; j < mUnits; j++ {
 			val := col.At(j, 0)
 			col.SetVec(j, val*(max[i]-min[i])+min[i])
 		}
@@ -46,21 +96,89 @@ func RandInit(inMx *mat64.Dense, rows int) (*mat64.Dense, error) {
 
 // LinInit returns a matrix initialized to values lying in a linear space
 // spanned by the top principal components of the values stored in the matrix passed in
-// as a parameter. The returned matrix has rows number of rows and
+// as a parameter. The returned matrix has mUnits number of rows and
 // as many columns as the input matrix passed in as a parameter
 // It fails with error if the new matrix could not be initialized or if inMx is nil.
-func LinInit(inMx *mat64.Dense, rows int) (*mat64.Dense, error) {
+func LinInit(inMx *mat64.Dense, mUnits int, gridDims []int) (*mat64.Dense, error) {
 	// if nil matrix is passed in, return error
 	if inMx == nil {
 		return nil, fmt.Errorf("Invalid input matrix: %v\n", inMx)
 	}
+	r, _ := inMx.Dims()
+	// Linear initialization requires at least 2 samples
+	if r < 2 {
+		return nil, fmt.Errorf("Insufficient number of samples: %d\n", r)
+	}
 	return nil, nil
 }
 
-// PlaneGridCoords returns a matrix that contains planar coordinates of SOM units
-// stored row by row. Planar coordinates naturally imply two columns.
-// It fails with error if the requested unit shape is unsupported or
-// if the matrix fails to be initialized
-func PlaneGridCoords(uShape string) (*mat64.Dense, error) {
-	return nil, nil
+// PlaneGridCoords returns a matrix that contains coordinates of SOM units
+// stored by row. Planar coordinates naturally imply two columns: x and y dimensions
+// It fails with error if the requested unit shape is unsupported or if the incorrect
+// dimensions are supplied: sims slice can't be nil nor can its length be bigger than 2
+func PlaneGridCoords(uShape string, dims []int) (*mat64.Dense, error) {
+	// unsupported SOM unit shape
+	if _, ok := UShape[uShape]; !ok {
+		return nil, fmt.Errorf("Unsupported unit shape: %s\n", uShape)
+	}
+	// map dims can't be nil or bigger than 2
+	mDims := len(dims)
+	if dims == nil || mDims != 2 {
+		return nil, fmt.Errorf("Invalid plane dimensions supplied: %v\n", dims)
+	}
+	mUnits := utils.IntProduct(dims)
+	coords := mat64.NewDense(mUnits, mDims, nil)
+	// we need coordinates pairs [x,y] to populate coords matrix
+	xDim, yDim := dims[0], dims[1]
+	xCoords := makeXCoords(mUnits, xDim)
+	yCoords := makeYCoords(mUnits, yDim)
+	// if hexagon this will make distances of a unit to all its six neighbors equal
+	if strings.EqualFold(uShape, "hexagon") {
+		// offset x-coordinates of every other row by 0.5
+		seq := mUnits / xDim
+		for i := 0; i < seq; i++ {
+			for j := 1 + i*xDim; j < (i+1)*xDim; j += 2 {
+				xCoords[j] += 0.5
+			}
+		}
+		// y-coordinates are multiplied by sqrt(0.75)
+		for i := 0; i < mUnits; i++ {
+			yCoords[i] *= math.Sqrt(0.75)
+		}
+	}
+	// populate coords matrix with coordinates
+	coords.SetCol(0, xCoords)
+	coords.SetCol(1, yCoords)
+	return coords, nil
+}
+
+// makeXCoords generates X-coords and returns them in a slice
+// X coordinats look like this: 0 0 0 1 1 1 2 2 2
+func makeXCoords(mUnits, dim int) []float64 {
+	// allocate coords array
+	x := make([]float64, mUnits)
+	val := 0.0
+	for i := 0; i < mUnits; i++ {
+		if i != 0 && i%dim == 0 {
+			val += 1.0
+		}
+		x[i] = val
+	}
+	return x
+}
+
+// makeYCoords generates Y-coords and returns them in a slice
+// Y coordinats look like this: 0 1 2 0 1 2 0 1 2
+func makeYCoords(mUnits, dim int) []float64 {
+	y := make([]float64, mUnits)
+	// generate Y-coords
+	val := 0.0
+	for i := 0; i < mUnits; i++ {
+		if i != 0 && i%dim == 0 {
+			val = 0.0
+		}
+		y[i] = val
+		val += 1.0
+	}
+	return y
 }

--- a/som/grid_test.go
+++ b/som/grid_test.go
@@ -7,6 +7,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGridDims(t *testing.T) {
+	assert := assert.New(t)
+
+	uShape := "hexagon"
+	// 1D data with more than one sample
+	data := mat64.NewDense(2, 1, []float64{2, 3})
+	dims, err := GridDims(data, uShape)
+	assert.NoError(err)
+	assert.EqualValues(dims, []int{1, 8})
+	// 2D data with one sample
+	data = mat64.NewDense(1, 2, []float64{2, 3})
+	dims, err = GridDims(data, uShape)
+	assert.NoError(err)
+	assert.EqualValues(dims, []int{2, 2})
+	// 2D+ data with more than one sample
+	data = mat64.NewDense(6, 4, []float64{
+		5.1, 3.5, 1.4, 0.2,
+		4.9, 3.0, 1.4, 0.2,
+		4.7, 3.2, 1.3, 0.2,
+		4.6, 3.1, 1.5, 0.2,
+		5.0, 3.6, 1.4, 0.2,
+		5.4, 3.9, 1.7, 0.4,
+	})
+	dims, err = GridDims(data, uShape)
+	assert.NoError(err)
+	assert.EqualValues(dims, []int{4, 3})
+	// data matrix can't be nil
+	dims, err = GridDims(nil, uShape)
+	assert.Nil(dims)
+	assert.Error(err)
+}
+
 func TestRandInit(t *testing.T) {
 	assert := assert.New(t)
 
@@ -17,13 +49,13 @@ func TestRandInit(t *testing.T) {
 	assert.NotNil(inMx)
 
 	_, cols := inMx.Dims()
-	rows := 4
 	// initialize random matrix
-	randMx, err := RandInit(inMx, rows, nil)
+	xDim, yDim := 2, 2
+	randMx, err := RandInit(inMx, []int{xDim, yDim})
 	assert.NotNil(randMx)
 	assert.NoError(err)
 	r, c := randMx.Dims()
-	assert.Equal(rows, r)
+	assert.Equal(xDim*yDim, r)
 	assert.Equal(cols, c)
 	for i := 0; i < cols; i++ {
 		inCol := inMx.ColView(i)
@@ -33,92 +65,86 @@ func TestRandInit(t *testing.T) {
 	}
 
 	// nil input matrix
-	randMx, err = RandInit(nil, rows, nil)
+	randMx, err = RandInit(nil, nil)
+	assert.Nil(randMx)
+	assert.Error(err)
+	// nil dimensions
+	randMx, err = RandInit(inMx, nil)
 	assert.Nil(randMx)
 	assert.Error(err)
 	// negative number of rows
-	randMx, err = RandInit(inMx, -9, nil)
+	randMx, err = RandInit(inMx, []int{-4, 3})
 	assert.Nil(randMx)
 	assert.Error(err)
 	// empty matrix
 	emptyMx := mat64.NewDense(0, 0, nil)
-	randMx, err = RandInit(emptyMx, 10, nil)
+	randMx, err = RandInit(emptyMx, []int{2, 3})
 	assert.Nil(randMx)
 	assert.Error(err)
 }
 
-func TestMakeXCoords(t *testing.T) {
+func TestLinInit(t *testing.T) {
 	assert := assert.New(t)
 
-	testCases := []struct {
-		mUnits   int
-		xDim     int
-		expected []float64
-	}{
-		{6, 3, []float64{0.0, 0.0, 1.0, 1.0, 2.0, 2.0}},
-		{6, 2, []float64{0.0, 0.0, 0.0, 1.0, 1.0, 1.0}},
-	}
+	inMx := mat64.NewDense(6, 4, []float64{
+		5.1, 3.5, 1.4, 0.2,
+		4.9, 3.0, 1.4, 0.2,
+		4.7, 3.2, 1.3, 0.2,
+		4.6, 3.1, 1.5, 0.2,
+		5.0, 3.6, 1.4, 0.2,
+		5.4, 3.9, 1.7, 0.4,
+	})
+	_, cols := inMx.Dims()
 
-	for _, tc := range testCases {
-		xCoords := makeXCoords(tc.mUnits, tc.xDim)
-		assert.EqualValues(xCoords, tc.expected)
-	}
+	xDim, yDim := 5, 2
+	linMx, err := LinInit(inMx, []int{xDim, yDim})
+	assert.NotNil(linMx)
+	assert.NoError(err)
+	// check if the dimensions are correct munits x datadim
+	linR, linC := linMx.Dims()
+	assert.Equal(linR, xDim*yDim)
+	assert.Equal(linC, cols)
+	// data is nil
+	linMx, err = LinInit(nil, []int{1, 2})
+	assert.Nil(linMx)
+	assert.Error(err)
+	// nil dimensions
+	linMx, err = LinInit(inMx, nil)
+	assert.Nil(linMx)
+	assert.Error(err)
+	// non positive dimensions supplied
+	linMx, err = LinInit(inMx, []int{-1, 2})
+	assert.Nil(linMx)
+	assert.Error(err)
+	// insufficient number of samples
+	inMx = mat64.NewDense(1, 2, []float64{1, 1})
+	linMx, err = LinInit(inMx, []int{5, 2})
+	assert.Nil(linMx)
+	assert.Error(err)
 }
 
-func TestMakeYCoords(t *testing.T) {
+func TestGridCoords(t *testing.T) {
 	assert := assert.New(t)
 
-	testCases := []struct {
-		mUnits   int
-		yDim     int
-		expected []float64
-	}{
-
-		{6, 2, []float64{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}},
-		{6, 3, []float64{0.0, 1.0, 2.0, 0.0, 1.0, 2.0}},
-	}
-
-	for _, tc := range testCases {
-		yCoords := makeYCoords(tc.mUnits, tc.yDim)
-		assert.EqualValues(yCoords, tc.expected)
-	}
-}
-
-func TestPlaneGridCoords(t *testing.T) {
-	assert := assert.New(t)
-
-	// incorrect units shape
-	coords, err := PlaneGridCoords("fooshape", []int{1, 2})
-	assert.Nil(coords)
-	assert.Error(err)
-	// incprrect dimensions
-	coords, err = PlaneGridCoords("hexagon", nil)
-	assert.Nil(coords)
-	assert.Error(err)
-	coords, err = PlaneGridCoords("hexagon", []int{1, 2, 3})
-	assert.Nil(coords)
-	assert.Error(err)
-	// incorrect number of units
-	coords, err = PlaneGridCoords("hexagon", []int{-1, 2})
-	assert.Nil(coords)
-	assert.Error(err)
 	// hexagon shape
-	dims := []int{3, 2}
+	dims := []int{4, 2}
 	mUnits := dims[0] * dims[1]
 	mDims := len(dims)
 	expMx := mat64.NewDense(mUnits, mDims, []float64{
 		0.0, 0.0,
-		0.5, 0.8660,
+		0.5, 0.866,
+		0.0, 1.732,
+		0.5, 2.598,
 		1.0, 0.0,
-		1.5, 0.8660,
-		2.0, 0.0,
-		2.5, 0.8660})
-	coords, err = PlaneGridCoords("hexagon", dims)
+		1.5, 0.866,
+		1.0, 1.732,
+		1.5, 2.598})
+	coords, err := GridCoords("hexagon", dims)
 	assert.NotNil(coords)
 	assert.NoError(err)
 	assert.True(mat64.EqualApprox(coords, expMx, 0.01))
 	// rectangle shape
-	dims = []int{2, 3}
+	dims = []int{3, 2}
 	mUnits = dims[0] * dims[1]
 	mDims = len(dims)
 	expMx = mat64.NewDense(mUnits, mDims, []float64{
@@ -128,28 +154,24 @@ func TestPlaneGridCoords(t *testing.T) {
 		1.0, 0.0,
 		1.0, 1.0,
 		1.0, 2.0})
-	coords, err = PlaneGridCoords("rectangle", dims)
+	coords, err = GridCoords("rectangle", dims)
 	assert.NotNil(coords)
 	assert.NoError(err)
 	assert.True(mat64.EqualApprox(coords, expMx, 0.01))
-}
-
-func TestLinInit(t *testing.T) {
-	assert := assert.New(t)
-
-	//inMx := mat64.NewDense(3, 4, []float64{
-	//	5.1, 3.5, 1.4, 0.2,
-	//	4.9, 3.0, 1.4, 0.2,
-	//	4.7, 3.2, 1.3, 0.2,
-	//})
-	//rows, cols := inMx.Dims()
-
-	linMx, err := LinInit(nil, 10, nil)
-	assert.Nil(linMx)
+	// incorrect units shape
+	coords, err = GridCoords("fooshape", []int{2, 2})
+	assert.Nil(coords)
 	assert.Error(err)
-	// insufficient number of samples
-	inMx := mat64.NewDense(1, 2, []float64{1, 1})
-	linMx, err = LinInit(inMx, 10, nil)
-	assert.Nil(linMx)
+	// nil dimensions
+	coords, err = GridCoords("hexagon", nil)
+	assert.Nil(coords)
+	assert.Error(err)
+	// unsupported number of dimensions
+	coords, err = GridCoords("hexagon", []int{1, 2, 3, 4})
+	assert.Nil(coords)
+	assert.Error(err)
+	// negative plane dimensions
+	coords, err = GridCoords("hexagon", []int{-1, 2})
+	assert.Nil(coords)
 	assert.Error(err)
 }

--- a/som/grid_test.go
+++ b/som/grid_test.go
@@ -47,6 +47,93 @@ func TestRandInit(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestMakeXCoords(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		mUnits   int
+		xDim     int
+		expected []float64
+	}{
+		{6, 3, []float64{0.0, 0.0, 1.0, 1.0, 2.0, 2.0}},
+		{6, 2, []float64{0.0, 0.0, 0.0, 1.0, 1.0, 1.0}},
+	}
+
+	for _, tc := range testCases {
+		xCoords := makeXCoords(tc.mUnits, tc.xDim)
+		assert.EqualValues(xCoords, tc.expected)
+	}
+}
+
+func TestMakeYCoords(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		mUnits   int
+		yDim     int
+		expected []float64
+	}{
+
+		{6, 2, []float64{0.0, 1.0, 0.0, 1.0, 0.0, 1.0}},
+		{6, 3, []float64{0.0, 1.0, 2.0, 0.0, 1.0, 2.0}},
+	}
+
+	for _, tc := range testCases {
+		yCoords := makeYCoords(tc.mUnits, tc.yDim)
+		assert.EqualValues(yCoords, tc.expected)
+	}
+}
+
+func TestPlaneGridCoords(t *testing.T) {
+	assert := assert.New(t)
+
+	// incorrect units shape
+	coords, err := PlaneGridCoords("fooshape", []int{1, 2})
+	assert.Nil(coords)
+	assert.Error(err)
+	// incprrect dimensions
+	coords, err = PlaneGridCoords("hexagon", nil)
+	assert.Nil(coords)
+	assert.Error(err)
+	coords, err = PlaneGridCoords("hexagon", []int{1, 2, 3})
+	assert.Nil(coords)
+	assert.Error(err)
+	// incorrect number of units
+	coords, err = PlaneGridCoords("hexagon", []int{-1, 2})
+	assert.Nil(coords)
+	assert.Error(err)
+	// hexagon shape
+	dims := []int{3, 2}
+	mUnits := dims[0] * dims[1]
+	mDims := len(dims)
+	expMx := mat64.NewDense(mUnits, mDims, []float64{
+		0.0, 0.0,
+		0.5, 0.8660,
+		1.0, 0.0,
+		1.5, 0.8660,
+		2.0, 0.0,
+		2.5, 0.8660})
+	coords, err = PlaneGridCoords("hexagon", dims)
+	assert.NotNil(coords)
+	assert.NoError(err)
+	assert.True(mat64.EqualApprox(coords, expMx, 0.01))
+	// rectangle shape
+	dims = []int{2, 3}
+	mUnits = dims[0] * dims[1]
+	mDims = len(dims)
+	expMx = mat64.NewDense(mUnits, mDims, []float64{
+		0.0, 0.0,
+		0.0, 1.0,
+		0.0, 2.0,
+		1.0, 0.0,
+		1.0, 1.0,
+		1.0, 2.0})
+	coords, err = PlaneGridCoords("rectangle", dims)
+	assert.NotNil(coords)
+	assert.NoError(err)
+	assert.True(mat64.EqualApprox(coords, expMx, 0.01))
+}
+
 func TestLinInit(t *testing.T) {
 	assert := assert.New(t)
 

--- a/som/grid_test.go
+++ b/som/grid_test.go
@@ -19,7 +19,7 @@ func TestRandInit(t *testing.T) {
 	_, cols := inMx.Dims()
 	rows := 4
 	// initialize random matrix
-	randMx, err := RandInit(inMx, rows)
+	randMx, err := RandInit(inMx, rows, nil)
 	assert.NotNil(randMx)
 	assert.NoError(err)
 	r, c := randMx.Dims()
@@ -33,16 +33,36 @@ func TestRandInit(t *testing.T) {
 	}
 
 	// nil input matrix
-	randMx, err = RandInit(nil, rows)
+	randMx, err = RandInit(nil, rows, nil)
 	assert.Nil(randMx)
 	assert.Error(err)
 	// negative number of rows
-	randMx, err = RandInit(inMx, -9)
+	randMx, err = RandInit(inMx, -9, nil)
 	assert.Nil(randMx)
 	assert.Error(err)
 	// empty matrix
 	emptyMx := mat64.NewDense(0, 0, nil)
-	randMx, err = RandInit(emptyMx, 10)
+	randMx, err = RandInit(emptyMx, 10, nil)
 	assert.Nil(randMx)
+	assert.Error(err)
+}
+
+func TestLinInit(t *testing.T) {
+	assert := assert.New(t)
+
+	//inMx := mat64.NewDense(3, 4, []float64{
+	//	5.1, 3.5, 1.4, 0.2,
+	//	4.9, 3.0, 1.4, 0.2,
+	//	4.7, 3.2, 1.3, 0.2,
+	//})
+	//rows, cols := inMx.Dims()
+
+	linMx, err := LinInit(nil, 10, nil)
+	assert.Nil(linMx)
+	assert.Error(err)
+	// insufficient number of samples
+	inMx := mat64.NewDense(1, 2, []float64{1, 1})
+	linMx, err = LinInit(inMx, 10, nil)
+	assert.Nil(linMx)
 	assert.Error(err)
 }

--- a/som/som.go
+++ b/som/som.go
@@ -2,20 +2,16 @@ package som
 
 import (
 	"fmt"
-	"math"
-	"strings"
 
-	"github.com/gonum/floats"
 	"github.com/gonum/matrix/mat64"
-	"github.com/gonum/stat"
 	"github.com/milosgajdos83/gosom/pkg/utils"
 )
 
 // CodebookInitFunc defines SOM codebook initialization function
-type CodebookInitFunc func(*mat64.Dense, int) (*mat64.Dense, error)
+type CodebookInitFunc func(*mat64.Dense, int, []int) (*mat64.Dense, error)
 
 // CoordsInitFunc defines SOM grid coordinates initialization function
-type CoordsInitFunc func(string) (*mat64.Dense, error)
+type CoordsInitFunc func(string, []int) (*mat64.Dense, error)
 
 // NeighbFunc defines SOM neighbourhood function
 type NeighbFunc func(float64, float64) float64
@@ -55,20 +51,20 @@ func NewMap(c *Config, initFunc CodebookInitFunc, data *mat64.Dense) (*Map, erro
 		return nil, fmt.Errorf("Invalid input data: %v\n", data)
 	}
 	// compute the number of map units
-	mapUnits := utils.IntProduct(c.Dims)
-	if mapUnits <= 1 {
-		dims, err := gridDims(data, c.UShape)
-		if err != nil {
-			return nil, err
-		}
-		mapUnits = utils.IntProduct(dims)
-		// set map dims to newl calculated dims
-		c.Dims = dims
+	mUnits := utils.IntProduct(c.Dims)
+	if mUnits <= 1 {
+		return nil, fmt.Errorf("Incorrect map size dimensions: %v\n", c.Dims)
 	}
 	// initialize codebook
-	codebook, err := initFunc(data, mapUnits)
+	codebook, err := initFunc(data, mUnits, c.Dims)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize codebook: %s\n", err)
+	}
+	// codebook vectors must have same number of dimensions as data
+	_, dataDim := data.Dims()
+	_, cbCols := codebook.Dims()
+	if cbCols != dataDim {
+		return nil, fmt.Errorf("")
 	}
 	// return pointer to new map
 	return &Map{
@@ -94,49 +90,4 @@ func (m Map) UCoords() *mat64.Dense {
 // Bmus returns a matrix which contains SOM indices of Best Match Units (BMUs)
 func (m Map) Bmus() []int {
 	return m.bmus
-}
-
-// gridDims tries to estimate the best dimensions of map from data matrix and given unit shape.
-// It determines the grid size from eigenvectors of input data: the grid dimensions are
-// calculated from the ratio of two highest input eigenvalues.
-// It returns error if the map dimensions could not be calculated.
-func gridDims(data *mat64.Dense, uShape string) ([]int, error) {
-	dataLen, dataDim := data.Dims()
-	// this is a simple heuristic - you can pick the scale > 5
-	mapUnits := math.Ceil(5 * math.Sqrt(float64(dataLen)))
-	// if the data is 1D - we return [1 x mapUnits] map dimensions
-	if dataDim == 1 && dataLen > 1 {
-		return []int{1, int(mapUnits)}, nil
-	}
-	// Not enough data to calculate eigenvectors
-	// We will use heuristic: number of mapUnits = square area of SOM
-	if dataLen < 2 {
-		gDim := math.Sqrt(mapUnits)
-		return []int{int(gDim), int(gDim)}, nil
-	}
-	// We have more than 2 samples and more than 1D data
-	// Calculate eigenvalue ie. SVD singular values
-	_, eigVals, ok := stat.PrincipalComponents(data, nil)
-	if !ok {
-		return nil, fmt.Errorf("Could not determine Principal Components")
-	}
-	// by default we use 1:1 ratio of the map
-	ratio := 1.0
-	// pick first two components: we only support 2D data maps
-	// length check here is redundant, but let's make sure just in case
-	if len(eigVals) >= 2 {
-		if eigVals[0] != 0 && eigVals[1]*mapUnits >= eigVals[0] {
-			ratio = math.Sqrt(eigVals[0] / eigVals[1])
-		}
-	}
-	// If the unit shape is hexagon, the ratio is modified a bit to take it into account
-	// Remember when using hexagon we don't get rectangle so the area != dimA * dimB
-	tmpDim := math.Sqrt(mapUnits / ratio)
-	if strings.EqualFold(uShape, "hexagon") {
-		tmpDim = math.Sqrt(mapUnits / ratio * math.Sqrt(0.75))
-	}
-	yDim := int(floats.Min([]float64{mapUnits, tmpDim}))
-	xDim := int(mapUnits / float64(yDim))
-	// Return map dimensions
-	return []int{xDim, yDim}, nil
 }

--- a/som/som.go
+++ b/som/som.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CodebookInitFunc defines SOM codebook initialization function
-type CodebookInitFunc func(*mat64.Dense, int, []int) (*mat64.Dense, error)
+type CodebookInitFunc func(*mat64.Dense, []int) (*mat64.Dense, error)
 
 // CoordsInitFunc defines SOM grid coordinates initialization function
 type CoordsInitFunc func(string, []int) (*mat64.Dense, error)
@@ -56,15 +56,9 @@ func NewMap(c *Config, initFunc CodebookInitFunc, data *mat64.Dense) (*Map, erro
 		return nil, fmt.Errorf("Incorrect map size dimensions: %v\n", c.Dims)
 	}
 	// initialize codebook
-	codebook, err := initFunc(data, mUnits, c.Dims)
+	codebook, err := initFunc(data, c.Dims)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize codebook: %s\n", err)
-	}
-	// codebook vectors must have same number of dimensions as data
-	_, dataDim := data.Dims()
-	_, cbCols := codebook.Dims()
-	if cbCols != dataDim {
-		return nil, fmt.Errorf("")
 	}
 	// return pointer to new map
 	return &Map{

--- a/som/som_test.go
+++ b/som/som_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
-func mockInit(d *mat64.Dense, mUnits int) (*mat64.Dense, error) {
+func mockInit(d *mat64.Dense, mUnits int, dims []int) (*mat64.Dense, error) {
 	return nil, errors.New("Test error")
 }
 
@@ -75,8 +75,8 @@ func TestNewMap(t *testing.T) {
 	origDims := cSom.Dims
 	cSom.Dims = []int{0, 0}
 	m, err = NewMap(cSom, RandInit, dataMx)
-	assert.NotNil(m)
-	assert.NoError(err)
+	assert.Nil(m)
+	assert.Error(err)
 	cSom.Dims = origDims
 	// init func that always returns error
 	m, err = NewMap(cSom, mockInit, dataMx)
@@ -106,12 +106,12 @@ func TestGridDims(t *testing.T) {
 	uShape := "hexagon"
 	// 1D data with more than one sample
 	data := mat64.NewDense(2, 1, []float64{2, 3})
-	dims, err := gridDims(data, uShape)
+	dims, err := GridDims(data, uShape)
 	assert.NoError(err)
 	assert.EqualValues(dims, []int{1, 8})
 	// 2D data with one sample
 	data = mat64.NewDense(1, 2, []float64{2, 3})
-	dims, err = gridDims(data, uShape)
+	dims, err = GridDims(data, uShape)
 	assert.NoError(err)
 	assert.EqualValues(dims, []int{2, 2})
 	// 2D+ data with more than one sample
@@ -123,7 +123,7 @@ func TestGridDims(t *testing.T) {
 		5.0, 3.6, 1.4, 0.2,
 		5.4, 3.9, 1.7, 0.4,
 	})
-	dims, err = gridDims(data, uShape)
+	dims, err = GridDims(data, uShape)
 	assert.NoError(err)
 	assert.EqualValues(dims, []int{4, 3})
 }

--- a/som/som_test.go
+++ b/som/som_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 	os.Exit(retCode)
 }
 
-func mockInit(d *mat64.Dense, mUnits int, dims []int) (*mat64.Dense, error) {
+func mockInit(d *mat64.Dense, dims []int) (*mat64.Dense, error) {
 	return nil, errors.New("Test error")
 }
 
@@ -98,32 +98,4 @@ func TestCodebook(t *testing.T) {
 	cbRows, cbCols := codebook.Dims()
 	assert.Equal(mapUnits, cbRows)
 	assert.Equal(cols, cbCols)
-}
-
-func TestGridDims(t *testing.T) {
-	assert := assert.New(t)
-
-	uShape := "hexagon"
-	// 1D data with more than one sample
-	data := mat64.NewDense(2, 1, []float64{2, 3})
-	dims, err := GridDims(data, uShape)
-	assert.NoError(err)
-	assert.EqualValues(dims, []int{1, 8})
-	// 2D data with one sample
-	data = mat64.NewDense(1, 2, []float64{2, 3})
-	dims, err = GridDims(data, uShape)
-	assert.NoError(err)
-	assert.EqualValues(dims, []int{2, 2})
-	// 2D+ data with more than one sample
-	data = mat64.NewDense(6, 4, []float64{
-		5.1, 3.5, 1.4, 0.2,
-		4.9, 3.0, 1.4, 0.2,
-		4.7, 3.2, 1.3, 0.2,
-		4.6, 3.1, 1.5, 0.2,
-		5.0, 3.6, 1.4, 0.2,
-		5.4, 3.9, 1.7, 0.4,
-	})
-	dims, err = GridDims(data, uShape)
-	assert.NoError(err)
-	assert.EqualValues(dims, []int{4, 3})
 }


### PR DESCRIPTION
This PR introduces two major things:

- `GirdCoordinates` which allows to generate SOM grid coordinates given the arbitrary number of supplied dimensions
- `LinInit` - codebook initialization function which allows to initialize codebook matrix to values that span linear space defined by the specified number of principal components of training data 